### PR TITLE
Fix name clashes / Remove base_name option

### DIFF
--- a/priv/grpcbox_service_bhvr.erl
+++ b/priv/grpcbox_service_bhvr.erl
@@ -9,6 +9,6 @@
 
 {{#methods}}
 %% @doc {{^input_stream}}{{^output_stream}}Unary RPC{{/output_stream}}{{/input_stream}}
--callback {{method}}({{^input_stream}}{{#output_stream}}{{pb_module}}:{{input}}(), grpcbox_stream:t(){{/output_stream}}{{/input_stream}}{{#input_stream}}{{^output_stream}}reference(), grpcbox_stream:t(){{/output_stream}}{{#output_stream}}reference(), grpcbox_stream:t(){{/output_stream}}{{/input_stream}}{{^input_stream}}{{^output_stream}}ctx:t(), {{pb_module}}:{{input}}(){{/output_stream}}{{/input_stream}}) ->
-    {{#output_stream}}ok{{/output_stream}}{{^output_stream}}{ok, {{pb_module}}:{{output}}(), ctx:t()} | {noreply, ctx:t()}{{/output_stream}} | grpcbox_stream:grpc_error_response().
+-callback {{method}}({{^input_stream}}{{#output_stream}}'{{pb_module}}':'{{input}}'(), grpcbox_stream:t(){{/output_stream}}{{/input_stream}}{{#input_stream}}{{^output_stream}}reference(), grpcbox_stream:t(){{/output_stream}}{{#output_stream}}reference(), grpcbox_stream:t(){{/output_stream}}{{/input_stream}}{{^input_stream}}{{^output_stream}}ctx:t(), '{{pb_module}}':'{{input}}'(){{/output_stream}}{{/input_stream}}) ->
+    {{#output_stream}}ok{{/output_stream}}{{^output_stream}}{ok, '{{pb_module}}':'{{output}}'(), ctx:t()} | {noreply, ctx:t()}{{/output_stream}} | grpcbox_stream:grpc_error_response().
 {{/methods}}

--- a/priv/grpcbox_service_client.erl
+++ b/priv/grpcbox_service_client.erl
@@ -25,21 +25,21 @@
 
 {{#methods}}
 %% @doc {{^input_stream}}{{^output_stream}}Unary RPC{{/output_stream}}{{/input_stream}}
--spec {{method}}({{^input_stream}}{{pb_module}}:{{input}}(){{/input_stream}}) ->
-    {{^output_stream}}{{^input_stream}}{ok, {{pb_module}}:{{output}}(), grpcbox:metadata()}{{/input_stream}}{{#input_stream}}{ok, grpcbox_client:stream()}{{/input_stream}}{{/output_stream}}{{#output_stream}}{{^input_stream}}{ok, grpcbox_client:stream()}{{/input_stream}}{{#input_stream}}{ok, grpcbox_client:stream()}{{/input_stream}}{{/output_stream}} | grpcbox_stream:grpc_error_response() | {error, any()}.
+-spec {{method}}({{^input_stream}}'{{pb_module}}':'{{input}}'(){{/input_stream}}) ->
+    {{^output_stream}}{{^input_stream}}{ok, '{{pb_module}}':'{{output}}'(), grpcbox:metadata()}{{/input_stream}}{{#input_stream}}{ok, grpcbox_client:stream()}{{/input_stream}}{{/output_stream}}{{#output_stream}}{{^input_stream}}{ok, grpcbox_client:stream()}{{/input_stream}}{{#input_stream}}{ok, grpcbox_client:stream()}{{/input_stream}}{{/output_stream}} | grpcbox_stream:grpc_error_response() | {error, any()}.
 {{method}}({{^input_stream}}Input{{/input_stream}}) ->
     {{method}}(ctx:new(){{^input_stream}}, Input{{/input_stream}}, #{}).
 
--spec {{method}}(ctx:t(){{^input_stream}} | {{pb_module}}:{{input}}(){{/input_stream}}{{^input_stream}}, {{pb_module}}:{{input}}(){{/input_stream}} | grpcbox_client:options()) ->
-    {{^output_stream}}{{^input_stream}}{ok, {{pb_module}}:{{output}}(), grpcbox:metadata()}{{/input_stream}}{{#input_stream}}{ok, grpcbox_client:stream()}{{/input_stream}}{{/output_stream}}{{#output_stream}}{{^input_stream}}{ok, grpcbox_client:stream()}{{/input_stream}}{{#input_stream}}{ok, grpcbox_client:stream()}{{/input_stream}}{{/output_stream}} | grpcbox_stream:grpc_error_response() | {error, any()}.
+-spec {{method}}(ctx:t(){{^input_stream}} | '{{pb_module}}':'{{input}}'(){{/input_stream}}{{^input_stream}}, '{{pb_module}}':'{{input}}'(){{/input_stream}} | grpcbox_client:options()) ->
+    {{^output_stream}}{{^input_stream}}{ok, '{{pb_module}}':'{{output}}'(), grpcbox:metadata()}{{/input_stream}}{{#input_stream}}{ok, grpcbox_client:stream()}{{/input_stream}}{{/output_stream}}{{#output_stream}}{{^input_stream}}{ok, grpcbox_client:stream()}{{/input_stream}}{{#input_stream}}{ok, grpcbox_client:stream()}{{/input_stream}}{{/output_stream}} | grpcbox_stream:grpc_error_response() | {error, any()}.
 {{method}}(Ctx{{^input_stream}}, Input{{/input_stream}}) when ?is_ctx(Ctx) ->
     {{method}}(Ctx{{^input_stream}}, Input{{/input_stream}}, #{});
 {{method}}({{^input_stream}}Input, {{/input_stream}}Options) ->
     {{method}}(ctx:new(){{^input_stream}}, Input{{/input_stream}}, Options).
 
--spec {{method}}(ctx:t(){{^input_stream}}, {{pb_module}}:{{input}}(){{/input_stream}}, grpcbox_client:options()) ->
-    {{^output_stream}}{{^input_stream}}{ok, {{pb_module}}:{{output}}(), grpcbox:metadata()}{{/input_stream}}{{#input_stream}}{ok, grpcbox_client:stream()}{{/input_stream}}{{/output_stream}}{{#output_stream}}{{^input_stream}}{ok, grpcbox_client:stream()}{{/input_stream}}{{#input_stream}}{ok, grpcbox_client:stream()}{{/input_stream}}{{/output_stream}} | grpcbox_stream:grpc_error_response() | {error, any()}.
+-spec {{method}}(ctx:t(){{^input_stream}}, '{{pb_module}}':'{{input}}'(){{/input_stream}}, grpcbox_client:options()) ->
+    {{^output_stream}}{{^input_stream}}{ok, '{{pb_module}}':'{{output}}'(), grpcbox:metadata()}{{/input_stream}}{{#input_stream}}{ok, grpcbox_client:stream()}{{/input_stream}}{{/output_stream}}{{#output_stream}}{{^input_stream}}{ok, grpcbox_client:stream()}{{/input_stream}}{{#input_stream}}{ok, grpcbox_client:stream()}{{/input_stream}}{{/output_stream}} | grpcbox_stream:grpc_error_response() | {error, any()}.
 {{method}}(Ctx{{^input_stream}}, Input{{/input_stream}}, Options) ->
-    {{^output_stream}}{{^input_stream}}grpcbox_client:unary(Ctx, <<"/{{unmodified_service_name}}/{{unmodified_method}}">>, Input, ?DEF({{input}}, {{output}}, <<"{{message_type}}">>), Options){{/input_stream}}{{#input_stream}}grpcbox_client:stream(Ctx, <<"/{{unmodified_service_name}}/{{unmodified_method}}">>, ?DEF({{input}}, {{output}}, <<"{{message_type}}">>), Options){{/input_stream}}{{/output_stream}}{{#output_stream}}{{^input_stream}}grpcbox_client:stream(Ctx, <<"/{{unmodified_service_name}}/{{unmodified_method}}">>, Input, ?DEF({{input}}, {{output}}, <<"{{message_type}}">>), Options){{/input_stream}}{{#input_stream}}grpcbox_client:stream(Ctx, <<"/{{unmodified_service_name}}/{{unmodified_method}}">>, ?DEF({{input}}, {{output}}, <<"{{message_type}}">>), Options){{/input_stream}}{{/output_stream}}.
+    {{^output_stream}}{{^input_stream}}grpcbox_client:unary(Ctx, <<"/{{unmodified_service_name}}/{{unmodified_method}}">>, Input, ?DEF('{{input}}', '{{output}}', <<"{{message_type}}">>), Options){{/input_stream}}{{#input_stream}}grpcbox_client:stream(Ctx, <<"/{{unmodified_service_name}}/{{unmodified_method}}">>, ?DEF('{{input}}', '{{output}}', <<"{{message_type}}">>), Options){{/input_stream}}{{/output_stream}}{{#output_stream}}{{^input_stream}}grpcbox_client:stream(Ctx, <<"/{{unmodified_service_name}}/{{unmodified_method}}">>, Input, ?DEF('{{input}}', '{{output}}', <<"{{message_type}}">>), Options){{/input_stream}}{{#input_stream}}grpcbox_client:stream(Ctx, <<"/{{unmodified_service_name}}/{{unmodified_method}}">>, ?DEF('{{input}}', '{{output}}', <<"{{message_type}}">>), Options){{/input_stream}}{{/output_stream}}.
 
 {{/methods}}

--- a/src/grpcbox_plugin_prv.erl
+++ b/src/grpcbox_plugin_prv.erl
@@ -130,7 +130,6 @@ compile_pb(Filename, OutDir, BeamOutDir, GpbOpts) ->
         true ->
             rebar_log:log(info, "Writing ~s", [GeneratedPB]),
             case gpb_compile:file(Filename, [{rename,{msg_name,snake_case}},
-                                             {rename,{msg_fqname,base_name}},
                                              use_packages, maps,
                                              strings_as_binaries, {i, "."},
                                              {report_errors, false},


### PR DESCRIPTION
Currently `{rename,{msg_fqname,base_name}}` is always added to the gpb options, causing duplicate names to clash even if they come from different packages.

Remove the option and fix the templates so that they support arbitrary atom names.